### PR TITLE
Language autodetection and redesign language dialog

### DIFF
--- a/src/app/configuration.service.ts
+++ b/src/app/configuration.service.ts
@@ -6,8 +6,9 @@ import { Injectable } from '@angular/core';
 export class ConfigurationService {
 
   constructor() { }
+  public language = navigator.language.startsWith('de') ? 'de' : 'en';
 
-  public language = 'en';
-  public languageAlreadySet = false;
+  // only for unknown languages we want to ask for a language switch.
+  public languageAlreadySet = navigator.language.startsWith('de') || navigator.language.startsWith('en');
   public gpsState = false;
 }

--- a/src/app/tab1/tab1.page.ts
+++ b/src/app/tab1/tab1.page.ts
@@ -87,13 +87,13 @@ export class Tab1Page {
 
   public ionViewWillEnter() {
     const configurationService = this.configurationService;
+
     if (this.configurationService.languageAlreadySet === false) {
       this.alertController.create({
-        header: 'Rather in German?',
-        message: '',
+        header: 'Select your language / Wählen Sie Ihre Sprache',
         buttons: [
-            {text: 'Yes', handler() {configurationService.language = 'de'; configurationService.languageAlreadySet = true; }},
-            {text: 'No', handler() {configurationService.language = 'en'; configurationService.languageAlreadySet = true; }},
+            {text: 'Deutsch', handler() {configurationService.language = 'de'; configurationService.languageAlreadySet = true; }},
+            {text: 'English', handler() {configurationService.language = 'en'; configurationService.languageAlreadySet = true; }},
         ]
       }).then(alert => {
         alert.present();


### PR DESCRIPTION
Autodetect browser language and only show dialog when language settings
doesn't fit.

Dialog just asks for the language.